### PR TITLE
Fixed bugs in kalman filter implementation and some code clean up

### DIFF
--- a/src/kalman_filter.h
+++ b/src/kalman_filter.h
@@ -46,6 +46,18 @@ class KalmanFilter {
    */
   void UpdateEKF(const Eigen::VectorXd &z);
 
+  /**
+    Updates the part of the kalman filter equation that is independent
+    of type of sensor used.
+    @param y the y vector
+  */
+  void UpdateCommon(const Eigen::VectorXd &y);
+
+  /*
+  Normalizes the angle phi
+  **/
+  void NormalizeAngle(double& phi);
+
   // state vector
   Eigen::VectorXd x_;
 


### PR DESCRIPTION
This PR fixes to bugs that after 50 timesteps in the simulator were causing the kalman filter to predict "nan" values.
The fix includes:

- rho_dot on the radar kalman filter equation was not being applied the correct formula. It was missing being divided by "rho", which was adding noise to the kalman filter results

- Vector y was not being correctly normalized [-pi,pi] and was also contributing to the wrong measurements by the kalman filter